### PR TITLE
fix GifBuilder::argbTorgba

### DIFF
--- a/gif/gif_builder.cpp
+++ b/gif/gif_builder.cpp
@@ -32,9 +32,24 @@ void GifBuilder::argbTorgba(rlottie::Surface& s) {
 	uint32_t totalBytes = s.height() * s.bytesPerLine();
 
 	for (uint32_t i = 0; i < totalBytes; i += 4) {
-		unsigned char r = buffer[i + 2];
-		unsigned char b = buffer[i];
-		buffer[i] = r;
-		buffer[i + 2] = b;
+		unsigned char a = buffer[i + 3];
+		// compute only if alpha is non zero
+		if (a) {
+			unsigned char r = buffer[i + 2];
+			unsigned char g = buffer[i + 1];
+			unsigned char b = buffer[i];
+			if (a != 255) { //un premultiply
+			r = (r * 255) / a;
+			g = (g * 255) / a;
+			b = (b * 255) / a;
+
+			buffer[i] = r;
+			buffer[i + 1] = g;
+			buffer[i + 2] = b;
+		} else {
+			// only swizzle r and b
+			buffer[i] = r;
+			buffer[i + 2] = b;
+		}
 	}
 }

--- a/gif/gif_builder.cpp
+++ b/gif/gif_builder.cpp
@@ -39,17 +39,18 @@ void GifBuilder::argbTorgba(rlottie::Surface& s) {
 			unsigned char g = buffer[i + 1];
 			unsigned char b = buffer[i];
 			if (a != 255) { //un premultiply
-			r = (r * 255) / a;
-			g = (g * 255) / a;
-			b = (b * 255) / a;
+				r = (r * 255) / a;
+				g = (g * 255) / a;
+				b = (b * 255) / a;
 
-			buffer[i] = r;
-			buffer[i + 1] = g;
-			buffer[i + 2] = b;
-		} else {
-			// only swizzle r and b
-			buffer[i] = r;
-			buffer[i + 2] = b;
+				buffer[i] = r;
+				buffer[i + 1] = g;
+				buffer[i + 2] = b;
+			} else {
+				// only swizzle r and b
+				buffer[i] = r;
+				buffer[i + 2] = b;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hi,

Function of GifBuilder::argbTorgba may have some problems while dealing pixels in buffer.

According to:
https://gitter.im/rLottie-dev/community?at=5db6381ee469ef43587849b4
and
https://github.com/Samsung/rlottie/blob/29b391b95913877b7234543da8b4a9ec6d8175d0/src/wasm/rlottiewasm.cpp#L138