### PR TITLE
Use `basename(argv[0])` in help function

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,7 @@ bool convert(std::string filePath, auto width, auto height, auto alphaThreshold,
 }
 
 int main(int argc, const char** argv) {
-	argparse::ArgumentParser program("tgs-to-gif");
+	argparse::ArgumentParser program(basename(argv[0]));
 
 	program.add_argument("path")
 		.required()
@@ -103,4 +103,3 @@ int main(int argc, const char** argv) {
 	}
 
 }
-

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <argparse/argparse.hpp>
 #include <typeinfo>
+#include <libgen.h>
 
 #include "zstr/zstr.h"
 #include "gif/render.h"


### PR DESCRIPTION
In the current main.cpp code, the help function calls the executable `tgs-to-gif`, which works great! until the executable is renamed, to, e.g., `tgs-to-gif` or `tgs2gif`, the latter being the seeminly defacto standard for simple conversion programs (e.g., `apng2gif`, `dos2unix`, `help2man`, etc.)
This simple change allows the Usage line to display correctly when the binary is renamed or symlinked to another name.

Builds and works on Linux.