### PR TITLE
Potential fix for code scanning alert no. 26: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-docker.yml
+++ b/.github/workflows/test-docker.yml
@@ -12,6 +12,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   test-docker:
     name: Run docker tests 


### PR DESCRIPTION
Potential fix for [https://github.com/ed-asriyan/lottie-converter/security/code-scanning/26](https://github.com/ed-asriyan/lottie-converter/security/code-scanning/26)

Add an explicit `permissions` block to `.github/workflows/test-docker.yml` at the workflow root so it applies to all jobs (including `test-docker`).  
Best minimal fix without changing behavior is:

- `contents: read` (recommended baseline and sufficient for `actions/checkout` read operations)
- `packages: read` (commonly required when interacting with container/package artifacts; safe least-privilege addition for this Docker/artifact flow)

Edit region: directly after the `on:`/`workflow_call` inputs block and before `jobs:`.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
